### PR TITLE
update workflow to only run on forks

### DIFF
--- a/.github/workflows/check-meta-files.yml
+++ b/.github/workflows/check-meta-files.yml
@@ -9,6 +9,8 @@ permissions:
 
 jobs:
   check-meta-files:
+    # This job runs only if the PR is from a fork
+    if: github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
problem: local PR trigger jasp module check workflow. The update should ignore the workflow if the PR is from the same repo.