### PR TITLE
Jasp breusch pagan yaml

### DIFF
--- a/modules-metadata/jaspBreuschPagan.yml
+++ b/modules-metadata/jaspBreuschPagan.yml
@@ -1,2 +1,0 @@
-name: "jaspBreuschPagan"
-gitUrl: "https://github.com/matyasbukva/jaspBreuschPagan"

--- a/modules-metadata/jaspBreuschPagan.yml
+++ b/modules-metadata/jaspBreuschPagan.yml
@@ -1,0 +1,2 @@
+name: "jaspBreuschPagan"
+gitUrl: "https://github.com/matyasbukva/jaspBreuschPagan"


### PR DESCRIPTION
This PR adds a new community module: jaspBreuschPagan.

It performs the Breusch–Pagan test for heteroskedasticity in linear regression. The user provides the saved residuals of an already-fitted regression together with its predictors; the module runs the auxiliary regression and reports the LM = n × R² statistic with its χ² p-value, rendered as a native JASP table. Both the studentized (Koenker) and the original (1979) variants are supported.

Repository: https://github.com/matyasbukva/jaspBreuschPagan